### PR TITLE
Updates to support Crystal v0.25.1

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,5 +2,5 @@ version: 1.0
 shards:
   minitest:
     git: https://github.com/ysbaddaden/minitest.cr.git
-    version: 0.3.6
+    version: 0.4.0
 

--- a/shard.yml
+++ b/shard.yml
@@ -10,6 +10,6 @@ description: |
 development_dependencies:
   minitest:
     git: https://github.com/ysbaddaden/minitest.cr.git
-    version: ~> 0.3.5
+    version: ~> 0.4.0
 
 license: MIT

--- a/src/liquid/standard_filters.cr
+++ b/src/liquid/standard_filters.cr
@@ -193,13 +193,13 @@ module Liquid
                Time.epoch(input)
              else
                begin
-                 Time.parse(input.to_s, "%F %T")
+                 Time.parse(input.to_s, "%F %T", Time::Location::UTC)
                rescue # Time::Format::Error
                  begin
-                   Time.parse(input.to_s, "%c")
+                   Time.parse(input.to_s, "%c", Time::Location::UTC)
                  rescue
                    begin
-                     Time.parse(input.to_s, "%Y%m%d")
+                     Time.parse(input.to_s, "%Y%m%d", Time::Location::UTC)
                    rescue
                      nil
                    end

--- a/src/liquid/standard_filters.cr
+++ b/src/liquid/standard_filters.cr
@@ -193,13 +193,13 @@ module Liquid
                Time.epoch(input)
              else
                begin
-                 Time.parse(input.to_s, "%F %T", Time::Location::UTC)
+                 Time.parse(input.to_s, "%F %T", Time::Location.local)
                rescue # Time::Format::Error
                  begin
-                   Time.parse(input.to_s, "%c", Time::Location::UTC)
+                   Time.parse(input.to_s, "%c", Time::Location.local)
                  rescue
                    begin
-                     Time.parse(input.to_s, "%Y%m%d", Time::Location::UTC)
+                     Time.parse(input.to_s, "%Y%m%d", Time::Location.local)
                    rescue
                      nil
                    end

--- a/test/liquid/context_test.cr
+++ b/test/liquid/context_test.cr
@@ -86,8 +86,8 @@ class ContextTest < Minitest::Test
     context["num"] = 5
     assert_equal 5, context["num"]
 
-    context["time"] = Time.parse("2006-06-06 12:00:00", "%F", Time::Location::UTC)
-    assert_equal Time.parse("2006-06-06 12:00:00", "%F", Time::Location::UTC), context["time"]
+    context["time"] = Time.parse("2006-06-06 12:00:00", "%F", Time::Location.local)
+    assert_equal Time.parse("2006-06-06 12:00:00", "%F", Time::Location.local), context["time"]
 
     # context["date"] = Date.today
     # assert_equal Date.today, context["date"]

--- a/test/liquid/context_test.cr
+++ b/test/liquid/context_test.cr
@@ -86,8 +86,8 @@ class ContextTest < Minitest::Test
     context["num"] = 5
     assert_equal 5, context["num"]
 
-    context["time"] = Time.parse("2006-06-06 12:00:00", "%F")
-    assert_equal Time.parse("2006-06-06 12:00:00", "%F"), context["time"]
+    context["time"] = Time.parse("2006-06-06 12:00:00", "%F", Time::Location::UTC)
+    assert_equal Time.parse("2006-06-06 12:00:00", "%F", Time::Location::UTC), context["time"]
 
     # context["date"] = Date.today
     # assert_equal Date.today, context["date"]

--- a/test/liquid/standard_filter_test.cr
+++ b/test/liquid/standard_filter_test.cr
@@ -127,9 +127,9 @@ class StandardFiltersTest < Minitest::Test
   # end
 
   def test_date
-    assert_equal "May", @filters.date(Time.parse("2006-05-05 10:00:00", "%F %T"), "%B")
-    assert_equal "June", @filters.date(Time.parse("2006-06-05 10:00:00", "%F %T"), "%B")
-    assert_equal "July", @filters.date(Time.parse("2006-07-05 10:00:00", "%F %T"), "%B")
+    assert_equal "May", @filters.date(Time.parse("2006-05-05 10:00:00", "%F %T", Time::Location::UTC), "%B")
+    assert_equal "June", @filters.date(Time.parse("2006-06-05 10:00:00", "%F %T", Time::Location::UTC), "%B")
+    assert_equal "July", @filters.date(Time.parse("2006-07-05 10:00:00", "%F %T", Time::Location::UTC), "%B")
 
     assert_equal "May", @filters.date("2006-05-05 10:00:00", "%B")
     assert_equal "June", @filters.date("2006-06-05 10:00:00", "%B")
@@ -207,7 +207,7 @@ class StandardFiltersTest < Minitest::Test
     assert_match(/4\.(6{13,14})7/, Template.parse("{{ 14 | divided_by:'3.0' }}").render)
 
     assert_template_result "5", "{{ 15 | divided_by:3 }}"
-    assert_template_result "Liquid error: Division by zero", "{{ 5 | divided_by:0 }}"
+    assert_template_result "Liquid error: Division by 0", "{{ 5 | divided_by:0 }}"
   end
 
   def test_modulo

--- a/test/liquid/standard_filter_test.cr
+++ b/test/liquid/standard_filter_test.cr
@@ -127,9 +127,9 @@ class StandardFiltersTest < Minitest::Test
   # end
 
   def test_date
-    assert_equal "May", @filters.date(Time.parse("2006-05-05 10:00:00", "%F %T", Time::Location::UTC), "%B")
-    assert_equal "June", @filters.date(Time.parse("2006-06-05 10:00:00", "%F %T", Time::Location::UTC), "%B")
-    assert_equal "July", @filters.date(Time.parse("2006-07-05 10:00:00", "%F %T", Time::Location::UTC), "%B")
+    assert_equal "May", @filters.date(Time.parse("2006-05-05 10:00:00", "%F %T", Time::Location.local), "%B")
+    assert_equal "June", @filters.date(Time.parse("2006-06-05 10:00:00", "%F %T", Time::Location.local), "%B")
+    assert_equal "July", @filters.date(Time.parse("2006-07-05 10:00:00", "%F %T", Time::Location.local), "%B")
 
     assert_equal "May", @filters.date("2006-05-05 10:00:00", "%B")
     assert_equal "June", @filters.date("2006-06-05 10:00:00", "%B")


### PR DESCRIPTION
- Updates minitest to v0.4.0
- Adds default `Time::Location` as UTC