### PR TITLE
Fix Liquid::Drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ result = template.render({"user" => {"name" => "Matz"}})
 
 It's still a WIP, however much of the code and specs have been converted. Work
 needs to be done for added stability, adding missing filters, implementing
-missing tests and improving the data passing interface which is a bit clunky
-(ie: Liquid::Data)
+missing tests
 
 ## Todo
 
@@ -38,5 +37,3 @@ missing tests and improving the data passing interface which is a bit clunky
 
 * Template tokenize tests
 * All tests that expect an error to *not* be raised
-* Half of the Drop & Context tests
-* Half of the if/else tag tests

--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ missing tests
 
 * Template tokenize tests
 * All tests that expect an error to *not* be raised
+
+### Support for procs in templates
+
+* I'm not sure if I actually want to support this

--- a/shard.lock
+++ b/shard.lock
@@ -2,5 +2,5 @@ version: 2.0
 shards:
   minitest:
     git: https://github.com/ysbaddaden/minitest.cr.git
-    version: 0.5.1
+    version: 1.0.1
 

--- a/shard.yml
+++ b/shard.yml
@@ -10,6 +10,6 @@ description: |
 development_dependencies:
   minitest:
     git: https://github.com/ysbaddaden/minitest.cr.git
-    version: ~> 0.5.0
+    version: ~> 1.0.0
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: liquid-crystal
-version: 0.1.0
+version: 0.2.0
 authors:
   - Wesley Moxam <me@wmoxam.com>
 

--- a/src/liquid-crystal.cr
+++ b/src/liquid-crystal.cr
@@ -44,9 +44,10 @@ module Liquid
   TemplateParser             = /(#{PartialTemplateParser}|#{AnyStartingTag})/
   VariableParser             = /\[[^\]]+\]|#{VariableSegment}+\??/
 
-  alias Type = Nil | Bool | Int32 | Float32 | Int64 | Float64 | String | Time | Liquid::Drop | Array(Type) | Hash(String, Type) | Range(Int32, Int32) | Symbol | Liquid::FileSystem
+  alias Type = Nil | Bool | Int32 | Float32 | Int64 | Float64 | String | Time | Liquid::Drop | Liquid::Context | Array(Type) | Hash(String, Type) | Range(Int32, Int32) | Symbol | Liquid::FileSystem
 end
 
+require "./liquid/context"
 require "./liquid/drop"
 require "./liquid/file_system"
 
@@ -59,7 +60,6 @@ require "./liquid/filter"
 require "./liquid/register_collection"
 require "./liquid/strainer"
 require "./liquid/standard_filters"
-require "./liquid/context"
 require "./liquid/tag"
 require "./liquid/block"
 require "./liquid/document"

--- a/src/liquid/any.cr
+++ b/src/liquid/any.cr
@@ -3,7 +3,7 @@ module Liquid
     getter raw : Type
 
     def initialize(raw)
-      @raw = raw.as Type
+      @raw = raw
       @uninitialized = false
     end
 
@@ -56,8 +56,9 @@ module Liquid
       when Hash
         return object.has_key?(key)
       else
-        raise "expected Array or Hash for #has_key?(key : Type), " \
-              "not #{object.class}"
+        return false
+        # raise "expected Array or Hash for #has_key?(key : Type), " \
+        #       "not #{object.class}"
       end
     end
 

--- a/src/liquid/context.cr
+++ b/src/liquid/context.cr
@@ -225,6 +225,7 @@ module Liquid
       end
 
       variable = lookup.to_liquid
+      variable.context = self if variable.is_a?(Drop)
       # variable.context = self if variable.respond_to?(:context=)
 
       return variable

--- a/src/liquid/context.cr
+++ b/src/liquid/context.cr
@@ -157,6 +157,10 @@ module Liquid
       resolve(key) != nil
     end
 
+    def to_liquid
+      self
+    end
+
     # Look up variable, either resolve directly after considering the name.
     # We can directly handle Strings, digits, floats and booleans (true,false).
     # If no match is made we lookup the variable in the current scope and

--- a/src/liquid/drop.cr
+++ b/src/liquid/drop.cr
@@ -1,5 +1,4 @@
 module Liquid
-
   # A drop in liquid is a class which allows you to export DOM like things to
   # liquid.
   # Methods of drops are callable.
@@ -37,32 +36,36 @@ module Liquid
     # the macro type methods should only return methods defined in that class,
     # not any inherited methods
     def invoke_drop(method_or_key) : Liquid::Type
+      puts "invoke_drop"
       value = nil
       {% begin %}
       value = case method_or_key
       when nil, ""
+        puts "nil"
         nil
       {% for method in @type.methods %}
         {% if !method.name.ends_with?("=") &&
-            method.visibility == :public &&
-            !["context",
-              "before_method",
-              "invoke_drop",
-              "[]",
-              "has_key?",
-              "each",
-              "inspect"].any? {|meth| meth == method.name} %}
+                method.visibility == :public &&
+                !["context",
+                  "before_method",
+                  "invoke_drop",
+                  "[]",
+                  "has_key?",
+                  "each",
+                  "inspect"].any? { |meth| meth == method.name } %}
       when {{method.name.stringify}}
+        puts "{{method.name}}"
         self.{{method.name}}()
         {% end %}
       {% end %}
       else
+        puts "before_method"
         before_method(method_or_key)
       end
       {% end %}
 
-      if value.is_a?(Array)
-        value.map {|item| item.as Liquid::Type }
+      if value.is_a?(Array) || value.is_a?(Hash)
+        Liquid::Data.prepare(value)
       else
         value
       end

--- a/src/liquid/drop.cr
+++ b/src/liquid/drop.cr
@@ -44,14 +44,14 @@ module Liquid
         nil
       {% for method in @type.methods %}
         {% if !method.name.ends_with?("=") &&
-            method.visibility == :public &&
-            !["context",
-              "before_method",
-              "invoke_drop",
-              "[]",
-              "has_key?",
-              "each",
-              "inspect"].any? {|meth| meth == method.name} %}
+                method.visibility == :public &&
+                !["context",
+                  "before_method",
+                  "invoke_drop",
+                  "[]",
+                  "has_key?",
+                  "each",
+                  "inspect"].any? { |meth| meth == method.name } %}
       when {{method.name.stringify}}
         self.{{method.name}}()
         {% end %}
@@ -61,8 +61,8 @@ module Liquid
       end
       {% end %}
 
-      if value.is_a?(Array)
-        value.map {|item| item.as Liquid::Type }
+      if value.is_a?(Array) || value.is_a?(Hash)
+        Liquid::Data.prepare(value)
       else
         value
       end

--- a/src/liquid/drop.cr
+++ b/src/liquid/drop.cr
@@ -1,5 +1,4 @@
 module Liquid
-
   # A drop in liquid is a class which allows you to export DOM like things to
   # liquid.
   # Methods of drops are callable.
@@ -45,8 +44,7 @@ module Liquid
       {% for method in @type.methods %}
         {% if !method.name.ends_with?("=") &&
                 method.visibility == :public &&
-                !["context",
-                  "before_method",
+                !["before_method",
                   "invoke_drop",
                   "[]",
                   "has_key?",

--- a/test/liquid/block_test.cr
+++ b/test/liquid/block_test.cr
@@ -34,7 +34,7 @@ class BlockTest < Minitest::Test
     template = Liquid::Template.parse("  {{funk}} {{so}} {{brother}} ")
     assert_equal 7, template.root.try(&.nodelist).try(&.size)
     assert_equal [String, Variable, String, Variable, String, Variable, String],
-                 block_types(template.root.try(&.nodelist))
+      block_types(template.root.try(&.nodelist))
   end
 
   def test_with_block
@@ -43,13 +43,12 @@ class BlockTest < Minitest::Test
     assert_equal 3, template.root.try(&.nodelist).try(&.size)
   end
 
-  # def test_with_custom_tag
-  #   Liquid::Template.register_tag("testtag", Block)
-  #
-  #   assert_nothing_thrown do
-  #     template = Liquid::Template.parse( "{% testtag %} {% endtesttag %}")
-  #   end
-  # end
+  def test_with_custom_tag
+    Liquid::Template.register_tag("testtag", Block)
+
+    template = Liquid::Template.parse("{% testtag %} {% endtesttag %}")
+    assert_equal template.render, " "
+  end
 
   private def block_types(nodelist)
     return [] of Nil.class if nodelist.nil?

--- a/test/liquid/context_test.cr
+++ b/test/liquid/context_test.cr
@@ -88,8 +88,8 @@ class ContextTest < Minitest::Test
     context["time"] = Time.parse("2006-06-06 12:00:00", "%F", Time::Location.local)
     assert_equal Time.parse("2006-06-06 12:00:00", "%F", Time::Location.local), context["time"]
 
-    # context["date"] = Date.today
-    # assert_equal Date.today, context["date"]
+    # context["date"] = Time.local.date
+    # assert_equal Time.local.date, context["date"]
     #
     # now = DateTime.now
     # context["datetime"] = now
@@ -234,13 +234,13 @@ class ContextTest < Minitest::Test
     assert_equal "hello!", context["\"hello!\""]
   end
 
-  # def test_merge
-  #   context.merge({ "test" => "test" })
-  #   assert_equal "test", context["test"]
-  #   context.merge({ "test" => "newvalue", "foo" => "bar" })
-  #   assert_equal "newvalue", context["test"]
-  #   assert_equal "bar", context["foo"]
-  # end
+  def test_merge
+    context.merge({"test" => "test"})
+    assert_equal "test", context["test"]
+    context.merge({"test" => "newvalue", "foo" => "bar"})
+    assert_equal "newvalue", context["test"]
+    assert_equal "bar", context["foo"]
+  end
 
   def test_array_notation
     context["test"] = Data.prepare([1, 2, 3, 4, 5])
@@ -349,18 +349,18 @@ class ContextTest < Minitest::Test
   #   cents = {"cents" => {"amount" => HundredCentes.new}}
   #   context.merge(cents)
   #   assert_equal 100, context["cents.amount"]
-  #
+
   #   nested_cents = {"cents" => cents}
   #   context.merge(nested_cents)
   #   assert_equal 100, context["cents.cents.amount"]
   # end
-  #
+
   # def test_cents_through_drop
   #   cents = {"cents" => CentsDrop.new}
   #   context.merge(cents)
   #   assert_equal 100, context["cents.amount"]
   # end
-  #
+
   # def test_nested_cents_through_drop
   #   vars = {"vars" => {"cents" => CentsDrop.new}}
   #   context.merge(vars)
@@ -376,7 +376,7 @@ class ContextTest < Minitest::Test
   # def test_context_from_within_drop
   #   sensitive = {"test" => "123", "vars" => ContextSensitiveDrop.new(context)}
   #   context.merge(sensitive)
-  #
+
   #   assert_equal "123", context["test"]
   #   assert_equal "123", context["vars.test"]
   # end

--- a/test/liquid/context_test.cr
+++ b/test/liquid/context_test.cr
@@ -338,54 +338,54 @@ class ContextTest < Minitest::Test
     assert_equal "element151cm", context["product.variants.last.title"]
   end
 
-  # def test_cents
-  #   cents = {} of String => Type
-  #   cents["cents"] = HundredCentes.new
-  #   context.merge(cents)
-  #   assert_equal 100, context["cents"]
-  # end
+  def test_cents
+    cents = {} of String => Type
+    cents["cents"] = HundredCentes.new
+    context.merge(cents)
+    assert_equal 100, context["cents"]
+  end
 
-  # def test_nested_cents
-  #   cents = {"cents" => {"amount" => HundredCentes.new}}
-  #   context.merge(cents)
-  #   assert_equal 100, context["cents.amount"]
+  def test_nested_cents
+    cents = {"cents" => {"amount" => HundredCentes.new}}
+    context.merge(cents)
+    assert_equal 100, context["cents.amount"]
 
-  #   nested_cents = {"cents" => cents}
-  #   context.merge(nested_cents)
-  #   assert_equal 100, context["cents.cents.amount"]
-  # end
+    nested_cents = {"cents" => cents}
+    context.merge(nested_cents)
+    assert_equal 100, context["cents.cents.amount"]
+  end
 
-  # def test_cents_through_drop
-  #   cents = {"cents" => CentsDrop.new}
-  #   context.merge(cents)
-  #   assert_equal 100, context["cents.amount"]
-  # end
+  def test_cents_through_drop
+    cents = {"cents" => CentsDrop.new}
+    context.merge(cents)
+    assert_equal 100, context["cents.amount"]
+  end
 
-  # def test_nested_cents_through_drop
-  #   vars = {"vars" => {"cents" => CentsDrop.new}}
-  #   context.merge(vars)
-  #   assert_equal 100, context["vars.cents.amount"]
-  # end
-  #
-  # def test_drop_methods_with_question_marks
-  #   cents = {"cents" => CentsDrop.new}
-  #   context.merge(cents)
-  #   assert context["cents.non_zero?"]
-  # end
-  #
-  # def test_context_from_within_drop
-  #   sensitive = {"test" => "123", "vars" => ContextSensitiveDrop.new(context)}
-  #   context.merge(sensitive)
+  def test_nested_cents_through_drop
+    vars = {"vars" => {"cents" => CentsDrop.new}}
+    context.merge(vars)
+    assert_equal 100, context["vars.cents.amount"]
+  end
 
-  #   assert_equal "123", context["test"]
-  #   assert_equal "123", context["vars.test"]
-  # end
-  #
-  # def test_nested_context_from_within_drop
-  #   sensitive = {"test" => "123", "vars" => {"local" => ContextSensitiveDrop.new(context)}}
-  #   context.merge(sensitive)
-  #   assert_equal "123", context["vars.local.test"]
-  # end
+  def test_drop_methods_with_question_marks
+    cents = {"cents" => CentsDrop.new}
+    context.merge(cents)
+    assert context["cents.non_zero?"]
+  end
+
+  def test_context_from_within_drop
+    sensitive = {"test" => "123", "vars" => ContextSensitiveDrop.new(context)}
+    context.merge(sensitive)
+
+    assert_equal "123", context["test"]
+    assert_equal "123", context["vars.test"]
+  end
+
+  def test_nested_context_from_within_drop
+    sensitive = {"test" => "123", "vars" => {"local" => ContextSensitiveDrop.new(context)}}
+    context.merge(sensitive)
+    assert_equal "123", context["vars.local.test"]
+  end
 
   def test_ranges
     context.merge({"test" => "5"})
@@ -394,35 +394,35 @@ class ContextTest < Minitest::Test
     assert_equal (5..5), context["(test..test)"]
   end
 
-  # def test_cents_through_drop_nestedly
-  #   cents = {"cents" => CentsDrop.new}
-  #   context.merge(cents)
-  #   assert_equal 100, context["cents.amount"]
-  #
-  #   nested_cents = {"cents" => cents}
-  #   context.merge(nested_cents)
-  #   assert_equal 100, context["cents.cents.amount"]
-  #
-  #   triple_nested_cents = {"cents" => nested_cents}
-  #   context.merge(triple_nested_cents)
-  #   assert_equal 100, context["cents.cents.cents.amount"]
-  # end
-  #
-  # def test_drop_with_variable_called_only_once
-  #   context["counter"] = CounterDrop.new
-  #
-  #   assert_equal 1, context["counter.count"]
-  #   assert_equal 2, context["counter.count"]
-  #   assert_equal 3, context["counter.count"]
-  # end
-  #
-  # def test_drop_with_key_called_only_once
-  #   context["counter"] = CounterDrop.new
-  #
-  #   assert_equal 1, context["counter[\"count\"]"]
-  #   assert_equal 2, context["counter[\"count\"]"]
-  #   assert_equal 3, context["counter[\"count\"]"]
-  # end
+  def test_cents_through_drop_nestedly
+    cents = {"cents" => CentsDrop.new}
+    context.merge(cents)
+    assert_equal 100, context["cents.amount"]
+
+    nested_cents = {"cents" => cents}
+    context.merge(nested_cents)
+    assert_equal 100, context["cents.cents.amount"]
+
+    triple_nested_cents = {"cents" => nested_cents}
+    context.merge(triple_nested_cents)
+    assert_equal 100, context["cents.cents.cents.amount"]
+  end
+
+  def test_drop_with_variable_called_only_once
+    context["counter"] = CounterDrop.new
+
+    assert_equal 1, context["counter.count"]
+    assert_equal 2, context["counter.count"]
+    assert_equal 3, context["counter.count"]
+  end
+
+  def test_drop_with_key_called_only_once
+    context["counter"] = CounterDrop.new
+
+    assert_equal 1, context["counter[\"count\"]"]
+    assert_equal 2, context["counter[\"count\"]"]
+    assert_equal 3, context["counter[\"count\"]"]
+  end
 
   # # def test_proc_as_variable
   # #   context["dynamic"] = Proc.new { "Hello" }
@@ -486,9 +486,9 @@ class ContextTest < Minitest::Test
   # #   assert_equal 345392, context["magic"]
   # # end
 
-  # def test_to_liquid_and_context_at_first_level
-  #   context["category"] = Category.new("foobar", context)
-  #   assert_equal CategoryDrop, context["category"].class
-  #   assert_equal context, (context["category"].as CategoryDrop).context
-  # end
+  def test_to_liquid_and_context_at_first_level
+    context["category"] = Category.new("foobar", context)
+    assert_equal CategoryDrop, context["category"].class
+    assert_equal context, (context["category"].as CategoryDrop).context
+  end
 end # ContextTest

--- a/test/liquid/drop_test.cr
+++ b/test/liquid/drop_test.cr
@@ -65,83 +65,81 @@ class EnumerableDrop < Liquid::Drop
 end
 
 class DropsTest < Minitest::Test
-  def test_protected
-    product = ProductDrop.new
-    assert_nil product["callmenot"]
-  end
+  # def test_protected
+  #   product = ProductDrop.new
+  #   assert_nil product["callmenot"]
+  # end
 
-  def test_drop_does_only_respond_to_whitelisted_methods
-    product = ProductDrop.new
-    assert_nil product["inspect"]
-    assert_nil product["to_s"]
-    assert_nil product["whatever"]
-  end
+  # def test_drop_does_only_respond_to_whitelisted_methods
+  #   product = ProductDrop.new
+  #   assert_nil product["inspect"]
+  #   assert_nil product["to_s"]
+  #   assert_nil product["whatever"]
+  # end
 
-  def test_text_drop
-    product = ProductDrop.new
-    text_drop = product["texts"]
-    assert text_drop.is_a?(Liquid::Drop), "Didn't receive a drop"
-    if text_drop.is_a?(Liquid::Drop)
-      assert_equal "text1", text_drop["text"]
-    end
-  end
-
-  def test_text_array_drop
-    product = ProductDrop.new
-    text_drop = product["texts"]
-    assert text_drop.is_a?(Liquid::Drop), "Didn't receive a drop"
-    if text_drop.is_a?(Liquid::Drop)
-      assert_equal ["text1", "text2"], text_drop["array"]
-    end
-  end
-
-  def test_unknown_method
-    product = ProductDrop.new
-    catchall = product["catchall"]
-    assert catchall.is_a?(Liquid::Drop), "Didn't receive a drop"
-    if catchall.is_a?(Liquid::Drop)
-      assert_equal "method: unknown", catchall["unknown"]
-    end
-  end
-
-  def test_integer_argument_drop
-    product = ProductDrop.new
-    catchall = product["catchall"]
-    assert catchall.is_a?(Liquid::Drop), "Didn't receive a drop"
-    if catchall.is_a?(Liquid::Drop)
-      assert_equal "method: 8", catchall["8"]
-    end
-  end
-
-  def test_protected
-    product = ProductDrop.new
-    assert_nil product["callmenot"]
-  end
-
-  def test_empty_string_value_access
-    product = ProductDrop.new
-    assert_nil product[""]
-  end
-
-  def test_nil_value_access
-    product = ProductDrop.new
-    assert_nil product[nil]
-  end
-
-  #   include Liquid
-  #
-  #   def test_product_drop
-  #     assert_nothing_raised do
-  #       tpl = Liquid::Template.parse( '  '  )
-  #       tpl.render('product' => ProductDrop.new)
-  #     end
+  # def test_text_drop
+  #   product = ProductDrop.new
+  #   text_drop = product["texts"]
+  #   assert text_drop.is_a?(Liquid::Drop), "Didn't receive a drop"
+  #   if text_drop.is_a?(Liquid::Drop)
+  #     assert_equal "text1", text_drop["text"]
   #   end
-  #
-  #   def test_drops_respond_to_to_liquid
-  #     assert_equal "text1", Liquid::Template.parse("{{ product.to_liquid.texts.text }}").render('product' => ProductDrop.new)
-  #     assert_equal "text1", Liquid::Template.parse('{{ product | map: "to_liquid" | map: "texts" | map: "text" }}').render('product' => ProductDrop.new)
+  # end
+
+  # def test_text_array_drop
+  #   product = ProductDrop.new
+  #   text_drop = product["texts"]
+  #   assert text_drop.is_a?(Liquid::Drop), "Didn't receive a drop"
+  #   if text_drop.is_a?(Liquid::Drop)
+  #     assert_equal ["text1", "text2"], text_drop["array"]
   #   end
-  #
+  # end
+
+  # def test_unknown_method
+  #   product = ProductDrop.new
+  #   catchall = product["catchall"]
+  #   assert catchall.is_a?(Liquid::Drop), "Didn't receive a drop"
+  #   if catchall.is_a?(Liquid::Drop)
+  #     assert_equal "method: unknown", catchall["unknown"]
+  #   end
+  # end
+
+  # def test_integer_argument_drop
+  #   product = ProductDrop.new
+  #   catchall = product["catchall"]
+  #   assert catchall.is_a?(Liquid::Drop), "Didn't receive a drop"
+  #   if catchall.is_a?(Liquid::Drop)
+  #     assert_equal "method: 8", catchall["8"]
+  #   end
+  # end
+
+  # def test_protected
+  #   product = ProductDrop.new
+  #   assert_nil product["callmenot"]
+  # end
+
+  # def test_empty_string_value_access
+  #   product = ProductDrop.new
+  #   assert_nil product[""]
+  # end
+
+  # def test_nil_value_access
+  #   product = ProductDrop.new
+  #   assert_nil product[nil]
+  # end
+
+  # def test_product_drop
+  #   tpl = Liquid::Template.parse(" ")
+  #   assert_equal tpl.render({"product" => ProductDrop.new}), " "
+  # end
+
+  # -------
+
+  # def test_drops_respond_to_to_liquid
+  #   assert_equal "text1", Liquid::Template.parse("{{ product.texts.text }}").render({"product" => ProductDrop.new})
+  #   assert_equal "text1", Liquid::Template.parse("{{ product | map: 'texts' | map: 'text' }}").render({"product" => ProductDrop.new})
+  # end
+
   #   def test_context_drop
   #     output = Liquid::Template.parse( ' {{ context.bar }} '  ).render('context' => ContextDrop.new, 'bar' => "carrot")
   #     assert_equal ' carrot ', output
@@ -191,9 +189,9 @@ class DropsTest < Minitest::Test
   #   def test_enumerable_drop
   #     assert_equal '123', Liquid::Template.parse( '{% for c in collection %}{{c}}{% endfor %}').render('collection' => EnumerableDrop.new)
   #   end
-  #
-  #   def test_enumerable_drop_size
-  #     assert_equal '3', Liquid::Template.parse( '{{collection.size}}').render('collection' => EnumerableDrop.new)
-  #   end
 
+  def test_enumerable_drop_size
+    tpl = Liquid::Template.parse("{{collection.size}}")
+    assert_equal "3", tpl.render({"collection" => EnumerableDrop.new})
+  end
 end # DropsTest

--- a/test/liquid/drop_test.cr
+++ b/test/liquid/drop_test.cr
@@ -70,80 +70,79 @@ class DropsTest < Minitest::Test
     assert_nil product["callmenot"]
   end
 
-  # def test_drop_does_only_respond_to_whitelisted_methods
-  #   product = ProductDrop.new
-  #   assert_nil product["inspect"]
-  #   assert_nil product["to_s"]
-  #   assert_nil product["whatever"]
-  # end
+  def test_drop_does_only_respond_to_whitelisted_methods
+    product = ProductDrop.new
+    assert_nil product["inspect"]
+    assert_nil product["to_s"]
+    assert_nil product["whatever"]
+  end
 
-  # def test_text_drop
-  #   product = ProductDrop.new
-  #   text_drop = product["texts"]
-  #   assert text_drop.is_a?(Liquid::Drop), "Didn't receive a drop"
-  #   if text_drop.is_a?(Liquid::Drop)
-  #     assert_equal "text1", text_drop["text"]
-  #   end
-  # end
+  def test_text_drop
+    product = ProductDrop.new
+    text_drop = product["texts"]
+    assert text_drop.is_a?(Liquid::Drop), "Didn't receive a drop"
+    if text_drop.is_a?(Liquid::Drop)
+      assert_equal "text1", text_drop["text"]
+    end
+  end
 
-  # def test_text_array_drop
-  #   product = ProductDrop.new
-  #   text_drop = product["texts"]
-  #   assert text_drop.is_a?(Liquid::Drop), "Didn't receive a drop"
-  #   if text_drop.is_a?(Liquid::Drop)
-  #     assert_equal ["text1", "text2"], text_drop["array"]
-  #   end
-  # end
+  def test_text_array_drop
+    product = ProductDrop.new
+    text_drop = product["texts"]
+    assert text_drop.is_a?(Liquid::Drop), "Didn't receive a drop"
+    if text_drop.is_a?(Liquid::Drop)
+      assert_equal ["text1", "text2"], text_drop["array"]
+    end
+  end
 
-  # def test_unknown_method
-  #   product = ProductDrop.new
-  #   catchall = product["catchall"]
-  #   assert catchall.is_a?(Liquid::Drop), "Didn't receive a drop"
-  #   if catchall.is_a?(Liquid::Drop)
-  #     assert_equal "method: unknown", catchall["unknown"]
-  #   end
-  # end
+  def test_unknown_method
+    product = ProductDrop.new
+    catchall = product["catchall"]
+    assert catchall.is_a?(Liquid::Drop), "Didn't receive a drop"
+    if catchall.is_a?(Liquid::Drop)
+      assert_equal "method: unknown", catchall["unknown"]
+    end
+  end
 
-  # def test_integer_argument_drop
-  #   product = ProductDrop.new
-  #   catchall = product["catchall"]
-  #   assert catchall.is_a?(Liquid::Drop), "Didn't receive a drop"
-  #   if catchall.is_a?(Liquid::Drop)
-  #     assert_equal "method: 8", catchall["8"]
-  #   end
-  # end
+  def test_integer_argument_drop
+    product = ProductDrop.new
+    catchall = product["catchall"]
+    assert catchall.is_a?(Liquid::Drop), "Didn't receive a drop"
+    if catchall.is_a?(Liquid::Drop)
+      assert_equal "method: 8", catchall["8"]
+    end
+  end
 
-  # def test_protected
-  #   product = ProductDrop.new
-  #   assert_nil product["callmenot"]
-  # end
+  def test_protected
+    product = ProductDrop.new
+    assert_nil product["callmenot"]
+  end
 
-  # def test_empty_string_value_access
-  #   product = ProductDrop.new
-  #   assert_nil product[""]
-  # end
+  def test_empty_string_value_access
+    product = ProductDrop.new
+    assert_nil product[""]
+  end
 
-  # def test_nil_value_access
-  #   product = ProductDrop.new
-  #   assert_nil product[nil]
-  # end
+  def test_nil_value_access
+    product = ProductDrop.new
+    assert_nil product[nil]
+  end
 
-  # def test_product_drop
-  #   tpl = Liquid::Template.parse(" ")
-  #   assert_equal tpl.render({"product" => ProductDrop.new}), " "
-  # end
+  def test_product_drop
+    tpl = Liquid::Template.parse(" ")
+    assert_equal tpl.render({"product" => ProductDrop.new}), " "
+  end
 
-  # -------
+  def test_drops_respond_to_to_liquid
+    assert_equal "text1", Liquid::Template.parse("{{ product.texts.text }}").render({"product" => ProductDrop.new})
+    # assert_equal "text1", Liquid::Template.parse("{{ product | map: 'texts' | map: 'text' }}").render({"product" => ProductDrop.new})
+  end
 
-  # def test_drops_respond_to_to_liquid
-  #   assert_equal "text1", Liquid::Template.parse("{{ product.texts.text }}").render({"product" => ProductDrop.new})
-  #   assert_equal "text1", Liquid::Template.parse("{{ product | map: 'texts' | map: 'text' }}").render({"product" => ProductDrop.new})
-  # end
+  def test_context_drop
+    output = Liquid::Template.parse(" {{ context.bar }} ").render({"context" => ContextDrop.new, "bar" => "carrot"})
+    assert_equal " carrot ", output
+  end
 
-  #   def test_context_drop
-  #     output = Liquid::Template.parse( ' {{ context.bar }} '  ).render('context' => ContextDrop.new, 'bar' => "carrot")
-  #     assert_equal ' carrot ', output
-  #   end
   #
   #   def test_nested_context_drop
   #     output = Liquid::Template.parse( ' {{ product.context.foo }} '  ).render('product' => ProductDrop.new, 'foo' => "monkey")

--- a/test/liquid/drop_test.cr
+++ b/test/liquid/drop_test.cr
@@ -70,78 +70,76 @@ class DropsTest < Minitest::Test
     assert_nil product["callmenot"]
   end
 
-  def test_drop_does_only_respond_to_whitelisted_methods
-    product = ProductDrop.new
-    assert_nil product["inspect"]
-    assert_nil product["to_s"]
-    assert_nil product["whatever"]
-  end
+  # def test_drop_does_only_respond_to_whitelisted_methods
+  #   product = ProductDrop.new
+  #   assert_nil product["inspect"]
+  #   assert_nil product["to_s"]
+  #   assert_nil product["whatever"]
+  # end
 
-  def test_text_drop
-    product = ProductDrop.new
-    text_drop = product["texts"]
-    assert text_drop.is_a?(Liquid::Drop), "Didn't receive a drop"
-    if text_drop.is_a?(Liquid::Drop)
-      assert_equal "text1", text_drop["text"]
-    end
-  end
-
-  def test_text_array_drop
-    product = ProductDrop.new
-    text_drop = product["texts"]
-    assert text_drop.is_a?(Liquid::Drop), "Didn't receive a drop"
-    if text_drop.is_a?(Liquid::Drop)
-      assert_equal ["text1", "text2"], text_drop["array"]
-    end
-  end
-
-  def test_unknown_method
-    product = ProductDrop.new
-    catchall = product["catchall"]
-    assert catchall.is_a?(Liquid::Drop), "Didn't receive a drop"
-    if catchall.is_a?(Liquid::Drop)
-      assert_equal "method: unknown", catchall["unknown"]
-    end
-  end
-
-  def test_integer_argument_drop
-    product = ProductDrop.new
-    catchall = product["catchall"]
-    assert catchall.is_a?(Liquid::Drop), "Didn't receive a drop"
-    if catchall.is_a?(Liquid::Drop)
-      assert_equal "method: 8", catchall["8"]
-    end
-  end
-
-  def test_protected
-    product = ProductDrop.new
-    assert_nil product["callmenot"]
-  end
-
-  def test_empty_string_value_access
-    product = ProductDrop.new
-    assert_nil product[""]
-  end
-
-  def test_nil_value_access
-    product = ProductDrop.new
-    assert_nil product[nil]
-  end
-
-  #   include Liquid
-  #
-  #   def test_product_drop
-  #     assert_nothing_raised do
-  #       tpl = Liquid::Template.parse( '  '  )
-  #       tpl.render('product' => ProductDrop.new)
-  #     end
+  # def test_text_drop
+  #   product = ProductDrop.new
+  #   text_drop = product["texts"]
+  #   assert text_drop.is_a?(Liquid::Drop), "Didn't receive a drop"
+  #   if text_drop.is_a?(Liquid::Drop)
+  #     assert_equal "text1", text_drop["text"]
   #   end
-  #
-  #   def test_drops_respond_to_to_liquid
-  #     assert_equal "text1", Liquid::Template.parse("{{ product.to_liquid.texts.text }}").render('product' => ProductDrop.new)
-  #     assert_equal "text1", Liquid::Template.parse('{{ product | map: "to_liquid" | map: "texts" | map: "text" }}').render('product' => ProductDrop.new)
+  # end
+
+  # def test_text_array_drop
+  #   product = ProductDrop.new
+  #   text_drop = product["texts"]
+  #   assert text_drop.is_a?(Liquid::Drop), "Didn't receive a drop"
+  #   if text_drop.is_a?(Liquid::Drop)
+  #     assert_equal ["text1", "text2"], text_drop["array"]
   #   end
-  #
+  # end
+
+  # def test_unknown_method
+  #   product = ProductDrop.new
+  #   catchall = product["catchall"]
+  #   assert catchall.is_a?(Liquid::Drop), "Didn't receive a drop"
+  #   if catchall.is_a?(Liquid::Drop)
+  #     assert_equal "method: unknown", catchall["unknown"]
+  #   end
+  # end
+
+  # def test_integer_argument_drop
+  #   product = ProductDrop.new
+  #   catchall = product["catchall"]
+  #   assert catchall.is_a?(Liquid::Drop), "Didn't receive a drop"
+  #   if catchall.is_a?(Liquid::Drop)
+  #     assert_equal "method: 8", catchall["8"]
+  #   end
+  # end
+
+  # def test_protected
+  #   product = ProductDrop.new
+  #   assert_nil product["callmenot"]
+  # end
+
+  # def test_empty_string_value_access
+  #   product = ProductDrop.new
+  #   assert_nil product[""]
+  # end
+
+  # def test_nil_value_access
+  #   product = ProductDrop.new
+  #   assert_nil product[nil]
+  # end
+
+  # def test_product_drop
+  #   tpl = Liquid::Template.parse(" ")
+  #   assert_equal tpl.render({"product" => ProductDrop.new}), " "
+  # end
+
+  # -------
+
+  # def test_drops_respond_to_to_liquid
+  #   assert_equal "text1", Liquid::Template.parse("{{ product.texts.text }}").render({"product" => ProductDrop.new})
+  #   assert_equal "text1", Liquid::Template.parse("{{ product | map: 'texts' | map: 'text' }}").render({"product" => ProductDrop.new})
+  # end
+
   #   def test_context_drop
   #     output = Liquid::Template.parse( ' {{ context.bar }} '  ).render('context' => ContextDrop.new, 'bar' => "carrot")
   #     assert_equal ' carrot ', output
@@ -191,9 +189,9 @@ class DropsTest < Minitest::Test
   #   def test_enumerable_drop
   #     assert_equal '123', Liquid::Template.parse( '{% for c in collection %}{{c}}{% endfor %}').render('collection' => EnumerableDrop.new)
   #   end
-  #
-  #   def test_enumerable_drop_size
-  #     assert_equal '3', Liquid::Template.parse( '{{collection.size}}').render('collection' => EnumerableDrop.new)
-  #   end
 
+  def test_enumerable_drop_size
+    tpl = Liquid::Template.parse("{{collection.size}}")
+    assert_equal "3", tpl.render({"collection" => EnumerableDrop.new})
+  end
 end # DropsTest

--- a/test/liquid/drop_test.cr
+++ b/test/liquid/drop_test.cr
@@ -143,18 +143,18 @@ class DropsTest < Minitest::Test
     assert_equal " carrot ", output
   end
 
-  #
-  #   def test_nested_context_drop
-  #     output = Liquid::Template.parse( ' {{ product.context.foo }} '  ).render('product' => ProductDrop.new, 'foo' => "monkey")
-  #     assert_equal ' monkey ', output
-  #   end
-  #
-  #   def test_object_methods_not_allowed
-  #     [:dup, :clone, :singleton_class, :eval, :class_eval, :inspect].each do |method|
-  #       output = Liquid::Template.parse(" {{ product.#{method} }} ").render('product' => ProductDrop.new)
-  #       assert_equal '  ', output
-  #     end
-  #   end
+  def test_nested_context_drop
+    output = Liquid::Template.parse(" {{ product.context.foo }} ").render({"product" => ProductDrop.new, "foo" => "monkey"})
+    assert_equal " monkey ", output
+  end
+
+  def test_object_methods_not_allowed
+    [:dup, :clone, :singleton_class, :eval, :class_eval, :inspect].each do |method|
+      output = Liquid::Template.parse(" {{ product.#{method} }} ").render({"product" => ProductDrop.new})
+      assert_equal "  ", output
+    end
+  end
+
   #
   #   def test_scope
   #     assert_equal '1', Liquid::Template.parse( '{{ context.scopes }}'  ).render('context' => ContextDrop.new)

--- a/test/liquid/drop_test.cr
+++ b/test/liquid/drop_test.cr
@@ -65,17 +65,17 @@ class EnumerableDrop < Liquid::Drop
 end
 
 class DropsTest < Minitest::Test
-  # def test_protected
-  #   product = ProductDrop.new
-  #   assert_nil product["callmenot"]
-  # end
+  def test_protected
+    product = ProductDrop.new
+    assert_nil product["callmenot"]
+  end
 
-  # def test_drop_does_only_respond_to_whitelisted_methods
-  #   product = ProductDrop.new
-  #   assert_nil product["inspect"]
-  #   assert_nil product["to_s"]
-  #   assert_nil product["whatever"]
-  # end
+  def test_drop_does_only_respond_to_whitelisted_methods
+    product = ProductDrop.new
+    assert_nil product["inspect"]
+    assert_nil product["to_s"]
+    assert_nil product["whatever"]
+  end
 
   def test_text_drop
     product = ProductDrop.new
@@ -155,39 +155,38 @@ class DropsTest < Minitest::Test
     end
   end
 
-  #
-  #   def test_scope
-  #     assert_equal '1', Liquid::Template.parse( '{{ context.scopes }}'  ).render('context' => ContextDrop.new)
-  #     assert_equal '2', Liquid::Template.parse( '{%for i in dummy%}{{ context.scopes }}{%endfor%}'  ).render('context' => ContextDrop.new, 'dummy' => [1])
-  #     assert_equal '3', Liquid::Template.parse( '{%for i in dummy%}{%for i in dummy%}{{ context.scopes }}{%endfor%}{%endfor%}'  ).render('context' => ContextDrop.new, 'dummy' => [1])
-  #   end
-  #
+  def test_scope
+    assert_equal "1", Liquid::Template.parse("{{ context.scopes }}").render({"context" => ContextDrop.new})
+    assert_equal "2", Liquid::Template.parse("{%for i in dummy%}{{ context.scopes }}{%endfor%}").render({"context" => ContextDrop.new, "dummy" => [1]})
+    assert_equal "3", Liquid::Template.parse("{%for i in dummy%}{%for i in dummy%}{{ context.scopes }}{%endfor%}{%endfor%}").render({"context" => ContextDrop.new, "dummy" => [1]})
+  end
+
   #   def test_scope_though_proc
   #     assert_equal '1', Liquid::Template.parse( '{{ s }}'  ).render('context' => ContextDrop.new, 's' => Proc.new{|c| c['context.scopes'] })
   #     assert_equal '2', Liquid::Template.parse( '{%for i in dummy%}{{ s }}{%endfor%}'  ).render('context' => ContextDrop.new, 's' => Proc.new{|c| c['context.scopes'] }, 'dummy' => [1])
   #     assert_equal '3', Liquid::Template.parse( '{%for i in dummy%}{%for i in dummy%}{{ s }}{%endfor%}{%endfor%}'  ).render('context' => ContextDrop.new, 's' => Proc.new{|c| c['context.scopes'] }, 'dummy' => [1])
   #   end
-  #
-  #   def test_scope_with_assigns
-  #     assert_equal 'variable', Liquid::Template.parse( '{% assign a = "variable"%}{{a}}'  ).render('context' => ContextDrop.new)
-  #     assert_equal 'variable', Liquid::Template.parse( '{% assign a = "variable"%}{%for i in dummy%}{{a}}{%endfor%}'  ).render('context' => ContextDrop.new, 'dummy' => [1])
-  #     assert_equal 'test', Liquid::Template.parse( '{% assign header_gif = "test"%}{{header_gif}}'  ).render('context' => ContextDrop.new)
-  #     assert_equal 'test', Liquid::Template.parse( "{% assign header_gif = 'test'%}{{header_gif}}"  ).render('context' => ContextDrop.new)
-  #   end
-  #
-  #   def test_scope_from_tags
-  #     assert_equal '1', Liquid::Template.parse( '{% for i in context.scopes_as_array %}{{i}}{% endfor %}'  ).render('context' => ContextDrop.new, 'dummy' => [1])
-  #     assert_equal '12', Liquid::Template.parse( '{%for a in dummy%}{% for i in context.scopes_as_array %}{{i}}{% endfor %}{% endfor %}'  ).render('context' => ContextDrop.new, 'dummy' => [1])
-  #     assert_equal '123', Liquid::Template.parse( '{%for a in dummy%}{%for a in dummy%}{% for i in context.scopes_as_array %}{{i}}{% endfor %}{% endfor %}{% endfor %}'  ).render('context' => ContextDrop.new, 'dummy' => [1])
-  #   end
-  #
-  #   def test_access_context_from_drop
-  #     assert_equal '123', Liquid::Template.parse( '{%for a in dummy%}{{ context.loop_pos }}{% endfor %}'  ).render('context' => ContextDrop.new, 'dummy' => [1,2,3])
-  #   end
-  #
-  #   def test_enumerable_drop
-  #     assert_equal '123', Liquid::Template.parse( '{% for c in collection %}{{c}}{% endfor %}').render('collection' => EnumerableDrop.new)
-  #   end
+
+  def test_scope_with_assigns
+    assert_equal "variable", Liquid::Template.parse("{% assign a = \"variable\"%}{{a}}").render({"context" => ContextDrop.new})
+    assert_equal "variable", Liquid::Template.parse("{% assign a = 'variable'%}{%for i in dummy%}{{a}}{%endfor%}").render({"context" => ContextDrop.new, "dummy" => [1]})
+    assert_equal "test", Liquid::Template.parse("{% assign header_gif = \"test\"%}{{header_gif}}").render({"context" => ContextDrop.new})
+    assert_equal "test", Liquid::Template.parse("{% assign header_gif = 'test'%}{{header_gif}}").render({"context" => ContextDrop.new})
+  end
+
+  def test_scope_from_tags
+    assert_equal "1", Liquid::Template.parse("{% for i in context.scopes_as_array %}{{i}}{% endfor %}").render({"context" => ContextDrop.new, "dummy" => [1]})
+    assert_equal "12", Liquid::Template.parse("{%for a in dummy%}{% for i in context.scopes_as_array %}{{i}}{% endfor %}{% endfor %}").render({"context" => ContextDrop.new, "dummy" => [1]})
+    assert_equal "123", Liquid::Template.parse("{%for a in dummy%}{%for a in dummy%}{% for i in context.scopes_as_array %}{{i}}{% endfor %}{% endfor %}{% endfor %}").render({"context" => ContextDrop.new, "dummy" => [1]})
+  end
+
+  def test_access_context_from_drop
+    assert_equal "123", Liquid::Template.parse("{%for a in dummy%}{{ context.loop_pos }}{% endfor %}").render({"context" => ContextDrop.new, "dummy" => [1, 2, 3]})
+  end
+
+  def test_enumerable_drop
+    assert_equal "123", Liquid::Template.parse("{% for c in collection %}{{c}}{% endfor %}").render({"collection" => EnumerableDrop.new})
+  end
 
   def test_enumerable_drop_size
     tpl = Liquid::Template.parse("{{collection.size}}")

--- a/test/liquid/error_handling_test.cr
+++ b/test/liquid/error_handling_test.cr
@@ -28,13 +28,13 @@ class ErrorHandlingTest < Minitest::Test
     end
   end
 
-  # def test_standard_error
-  #   template = Liquid::Template.parse(" {{ errors.standard_error }} ")
-  #   assert_equal " Liquid error: standard error ", template.render({"errors" => ErrorDrop.new})
+  def test_standard_error
+    template = Liquid::Template.parse(" {{ errors.standard_error }} ")
+    assert_equal " Liquid error: standard error ", template.render({"errors" => ErrorDrop.new})
 
-  #   assert_equal 1, template.errors.size
-  #   assert_equal StandardError, template.errors.first.class
-  # end
+    assert_equal 1, template.errors.size
+    assert_equal StandardError, template.errors.first.class
+  end
 
   #
   # def test_syntax

--- a/test/liquid/error_handling_test.cr
+++ b/test/liquid/error_handling_test.cr
@@ -29,14 +29,13 @@ class ErrorHandlingTest < Minitest::Test
   end
 
   # def test_standard_error
-  #   assert_nothing_raised do
-  #     template = Liquid::Template.parse( ' {{ errors.standard_error }} '  )
-  #     assert_equal ' Liquid error: standard error ', template.render('errors' => ErrorDrop.new)
-  #
-  #     assert_equal 1, template.errors.size
-  #     assert_equal StandardError, template.errors.first.class
-  #   end
+  #   template = Liquid::Template.parse(" {{ errors.standard_error }} ")
+  #   assert_equal " Liquid error: standard error ", template.render({"errors" => ErrorDrop.new})
+
+  #   assert_equal 1, template.errors.size
+  #   assert_equal StandardError, template.errors.first.class
   # end
+
   #
   # def test_syntax
   #

--- a/test/liquid/standard_filter_test.cr
+++ b/test/liquid/standard_filter_test.cr
@@ -1,26 +1,26 @@
 require "../test_helper"
 
-# class TestThing < Liquid::Drop
-#   def initialize
-#     super
-#     @foo = 0
-#   end
-#
-#   def to_s
-#     "woot: #{@foo}"
-#   end
-#
-#   def to_liquid
-#     @foo += 1
-#     self
-#   end
-# end
+class TestThing < Liquid::Drop
+  def initialize
+    super
+    @foo = 0
+  end
 
-#class TestDrop < Liquid::Drop
-#  def test
-#    "testfoo"
-#  end
-#end
+  def to_s
+    "woot: #{@foo}"
+  end
+
+  def to_liquid
+    @foo += 1
+    self
+  end
+end
+
+class TestDrop < Liquid::Drop
+  def test
+    "testfoo"
+  end
+end
 
 class StandardFiltersTest < Minitest::Test
   include Liquid
@@ -114,16 +114,16 @@ class StandardFiltersTest < Minitest::Test
   #   assert_equal "", Liquid::Template.parse("{{ 'foo' | map: 'inspect' }}").render
   # end
 
-  # def test_map_calls_to_liquid
-  #   t = TestThing.new
-  #   assert_equal "woot: 1", Liquid::Template.parse("{{ foo }}").render({"foo" => t.as Type})
-  # end
+  def test_map_calls_to_liquid
+    t = TestThing.new
+    assert_equal "woot: 1", Liquid::Template.parse("{{ foo }}").render({"foo" => t})
+  end
 
   # def test_map_over_proc
   #   drop = TestDrop.new
-  #   p = Proc.new{ drop }
+  #   p = Proc.new { drop }
   #   templ = "{{ procs | map: 'test' }}"
-  #   assert_equal "testfoo", Liquid::Template.parse(templ).render("procs" => [p])
+  #   assert_equal "testfoo", Liquid::Template.parse(templ).render({"procs" => [p]})
   # end
 
   def test_date
@@ -216,14 +216,14 @@ class StandardFiltersTest < Minitest::Test
 
   def test_append
     assigns = {"a" => "bc".as Type, "b" => "d".as Type}
-    assert_template_result("bcd","{{ a | append: 'd'}}",assigns)
+    assert_template_result("bcd", "{{ a | append: 'd'}}", assigns)
     assert_template_result("bcd", "{{ a | append: b}}", assigns)
   end
 
   def test_prepend
     assigns = {"a" => "bc".as Type, "b" => "a".as Type}
-    assert_template_result("abc","{{ a | prepend: 'a'}}",assigns)
-    assert_template_result("abc","{{ a | prepend: b}}",assigns)
+    assert_template_result("abc", "{{ a | prepend: 'a'}}", assigns)
+    assert_template_result("abc", "{{ a | prepend: b}}", assigns)
   end
 
   def test_cannot_access_private_methods


### PR DESCRIPTION
Liquid::Drop usage was resulting in crashes. I'm still a bit baffled by it but the root cause was casting the raw value of Liquid::Any to Liquid::Type in the initializer

I think the only reason I was doing that was to make earlier versions of the Crystal compiler happy.

Fixing the problem means that a ton more specs pass.